### PR TITLE
Adding missing migration necessary for CMS v3.3.1 or greater.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,8 +17,8 @@ Links
 Requires
 ********
 
-* Django >= 1.7;
-* `DjangoCMS`_ >= 3.0;
+* Django >= 1.8;
+* `DjangoCMS`_ >= 3.3.1;
 * `django-feedparser`_ >= 0.1.2;
 
 Install

--- a/cmsplugin_feedparser/migrations/0002_update_related_name.py
+++ b/cmsplugin_feedparser/migrations/0002_update_related_name.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cmsplugin_feedparser', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='feedparserpluginmodel',
+            name='cmsplugin_ptr',
+            field=models.OneToOneField(parent_link=True, related_name='cmsplugin_feedparser_feedparserpluginmodel', auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin'),
+        ),
+    ]

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     install_requires=[
-        'django-cms>=3.0.1',
+        'django-cms>=3.3.1',
         'django-feedparser>=0.2.0',
     ],
     include_package_data=True,


### PR DESCRIPTION
This migration is necessary when using Django CMS v3.3.1 or greater, because of changes to the related_name attribute of the cmsplugin_ptr field. Django CMS v3.3.1 or greater requires Django v1.8 or greater, and so the README has been updated to reflect this.

For more information on why this migration in necessary for CMS v3.3.1 or greater, see:
https://github.com/divio/django-cms/issues/5550
